### PR TITLE
Fix: sign error in sign with server

### DIFF
--- a/docs/example/sign_with_server.md
+++ b/docs/example/sign_with_server.md
@@ -9,8 +9,7 @@ You should get the network time form the server.
 This is an example of **the server** about how to return the right time to clients.
 
 ```java
-Calendar instance = Calendar.getInstance(TimeZone.getTimeZone("Asia/Beijing"));
-String gmtTime = QSSignatureUtil.formatGmtDate(instance.getTime());
+String gmtTime = QSSignatureUtil.formatGmtDate(new Date());
 return gmtTime;
 ```
 
@@ -50,6 +49,14 @@ try {
                 System.out.println("Url = " + output.getUrl());
                 }
             });
+            
+    /**
+     * There may be a time difference between the client and the server, and the result of the signature calculation is closely related to the time.
+     * So it is necessary to set the time used for the server's signature to the request.
+     * You can send strToSignature to the server to get the server's signature time.
+     * The concrete server example refers to the "The Local Time Is Incorrect".
+    **/
+    reqHandler.getBuilder().setHeader(QSConstant.HEADER_PARAM_KEY_DATE, gmtTime);
 
     // Step 3: get the strToSignature. Send this string to the server.
     String strToSignature = reqHandler.getStringToSignature();
@@ -60,13 +67,7 @@ try {
 
     // Step 5: set the signature to the request.
     reqHandler.setSignature("accessKey", serverAuthorization);
-    /**
-     * There may be a time difference between the client and the server, and the result of the signature calculation is closely related to the time.
-     * So it is necessary to set the time used for the server's signature to the request.
-     * You can send strToSignature to the server to get the server's signature time.
-     * The concrete server example refers to the "The Local Time Is Incorrect".
-    **/
-    reqHandler.getBuilder().setHeader(QSConstant.HEADER_PARAM_KEY_DATE, gmtTime);
+    
     // Step 6: send request. Async requests use the method sendAsync(), sync requests use the method send().
     reqHandler.sendAsync();
 

--- a/docs/example/sign_with_server_zh.md
+++ b/docs/example/sign_with_server_zh.md
@@ -7,8 +7,7 @@
 下面是一个关于**服务端**如何返回正确时间到客户端的示例。
 
 ```java
-Calendar instance = Calendar.getInstance(TimeZone.getTimeZone("Asia/Beijing"));
-String gmtTime = QSSignatureUtil.formatGmtDate(instance.getTime());
+String gmtTime = QSSignatureUtil.formatGmtDate(new Date());
 return gmtTime;
 ```
 
@@ -49,20 +48,23 @@ try {
                 }
             });
 
-    // 第三步：获取 strToSignature。将这个字符串发送到用户的 server 端。
-    String strToSignature = reqHandler.getStringToSignature();
-
-    // 第四步：serverAuthorization。server 端处理返回信息，服务端参考如下代码：
-    // String serverAuthorization = QSSignatureUtil.generateSignature("您的 secretKey", strToSignature);
-    String serverAuthorization = "您从服务端获取到的签名字符串";
-    // 第五步：将计算的签名设置到 request 中
-    reqHandler.setSignature("您的 accessKey", serverAuthorization);
     /**
      * 因客户端跟服务端通讯可能有时间差，而签名计算结果跟时间密切相关。
      * 因此需要将服务端计算签名时所用的时间设置到 request 中。
      * 您可以发送 strToSignature 到服务端以获取服务端签名的时间。具体服务端示例参考上述 "本地时间和网络时间不同步"。
     **/
     reqHandler.getBuilder().setHeader(QSConstant.HEADER_PARAM_KEY_DATE, gmtTime);
+    
+    // 第三步：获取 strToSignature。将这个字符串发送到用户的 server 端。
+    String strToSignature = reqHandler.getStringToSignature();
+
+    // 第四步：serverAuthorization。server 端处理返回信息，服务端参考如下代码：
+    // String serverAuthorization = QSSignatureUtil.generateSignature("您的 secretKey", strToSignature);
+    String serverAuthorization = "您从服务端获取到的签名字符串";
+    
+    // 第五步：将计算的签名设置到 request 中
+    reqHandler.setSignature("您的 accessKey", serverAuthorization);
+    
     // 第六步：发送请求。异步请求使用 sendAsync() 方法。同步请求使用 send() 方法。
     reqHandler.sendAsync();
 


### PR DESCRIPTION
修正用服务端签名，因时间矫正代码写在不正确的位置（实际签名之后）导致的签名错误。