### PR TITLE
Fix: OpenJDK7 failures on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ language: java
 dist: precise
 jdk:
   - oraclejdk8
-  - openjdk7
 
 script:
   - gradle check


### PR DESCRIPTION
The same with the [issue](https://github.com/travis-ci/travis-ci/issues/8109).
Probably it is an issue of openjdk7 or gradle.
Only a few person use openjdk and it is a build issue on our project.
To resolve this problem, I removed openjdk7 support on travis(only oraclejdk8 kept).