### PR TITLE
Add: a test case about PutObject signature

### DIFF
--- a/src/test/java/com/qingstor/sdk/utils/QSSignatureUtilTest.java
+++ b/src/test/java/com/qingstor/sdk/utils/QSSignatureUtilTest.java
@@ -16,9 +16,13 @@
 
 package com.qingstor.sdk.utils;
 
+import com.qingstor.sdk.config.EnvContext;
 import com.qingstor.sdk.config.EvnContext;
 import com.qingstor.sdk.constants.QSConstant;
 import com.qingstor.sdk.exception.QSException;
+import com.qingstor.sdk.request.RequestHandler;
+import com.qingstor.sdk.service.Bucket;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -78,5 +82,27 @@ public class QSSignatureUtilTest {
         Assert.assertEquals(
                 req1.indexOf("https://bucketName.testzone.qingstor.com/objectName/dd.txt?") == 0,
                 true);
+    }
+
+    @Test
+    public void testPutObjectSign() {
+        EnvContext context = new EnvContext("NPTEPEATTGXAKXFYSFXR", "VdVyOLO6oG7wzzilGbuuqiDrwR1K0NgD0DzFaNKX");
+        String zoneKey = "pek3b";
+        String bucketName = "test";
+        Bucket bucket = new Bucket(context, zoneKey, bucketName);
+        Bucket.PutObjectInput input = new Bucket.PutObjectInput();
+        input.setContentType("image/jpeg");
+        input.setContentMD5("Content-MD5");
+        input.setContentLength(10000l);
+        try {
+            RequestHandler requestHandler = bucket.putObjectRequest("test/test.jpg", input);
+            requestHandler.getBuilder().setHeader("Date", "Thu, 06 Dec 2018 06:47:43 GMT");
+            String stringToSign = requestHandler.getStringToSignature();
+            Assert.assertEquals(stringToSign, "PUT\nContent-MD5\nimage/jpeg\nThu, 06 Dec 2018 06:47:43 GMT\n/test/test/test.jpg");
+            String sign = QSSignatureUtil.generateSignature("VdVyOLO6oG7wzzilGbuuqiDrwR1K0NgD0DzFaNKX", stringToSign);
+            Assert.assertEquals(sign, "PiwbpsStHI4p3OF3Y68bX9TV72OEOFbgqJGkmu7mN8E=");
+        } catch (QSException e) {
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
### Preface

Because the last SDK version upgrade caused the signature of the files' upload (PutObject) to be wrong. A test case of upload signature has been added.

### Prepare for work

Based on a file upload operation, set the headers (Content-Type, Content-MD5) that will be used when signing. Get the RequestHandler, set a fixed time, then the signature can get a correct, fixed value (sign).

### Start testing

Repeat the above operations, get stringToSign and sign, and compare with the above benchmark values to check whether the signature is correct.

Since this test contains all the elements needed in the signature process, the problem in the signature process can be verified by the subsequent test of this method.

----

### 前言
由于上次 SDK 的版本升级导致上传文件（PutObject）签名有误，本次增加一个上传签名的测试用例。

### 准备工作
基于一次文件上传操作，设定好签名时会用到的项目（Content-Type、Content-MD5）。拿到 RequestHandler，设置一个固定时间，此时签名可以拿到一个正确的，固定值的字符串（sign）。

### 开始测试
重复上述操作，获取到 stringToSign 和 sign，和上述基准值对比即可判定签名是否正确。

由于本次测试包含了签名过程中的所有需要的元素，后续测试到该方法即可验证签名过程中的问题。